### PR TITLE
Update README with correct plurality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ There are a couple of configuration options that you will need to setup dependin
 
 ```yml
 # Comment to a new issue.
-issueOpened: >
+issuesOpened: >
   Thank you for raising an issue. We will try and get back to you as soon as possible.
 
   Please make sure you have given us as much context as possible.
@@ -61,5 +61,5 @@ pullRequestOpened: >
 | pullRequestEdited               | Message when pullRequest are edited                            |
 | pullRequestClosed               | Message when pullRequest are closed                            |
 | pullRequestReopened             | Message when pullRequest are reopened                          |
-| pullRequestsAssigned            | Message when pullRequests are assigned                         |
-| pullRequestsUnassigned          | Message when pullRequests are unassigned                       |
+| pullRequestAssigned            | Message when pullRequests are assigned                         |
+| pullRequestUnassigned          | Message when pullRequests are unassigned                       |


### PR DESCRIPTION
I just attempted to integrate this at https://github.com/dctech/speaking/pull/39 and was thrown off by what seems to be an issue in plurality — based on my read of the source and tests, `issues` should always be plural and `pullRequest` should always be single, as [defined in the GitHub Webhooks API](https://developer.github.com/webhooks/#events). 

Thanks for the great tool, and let me know if I’ve missed anything! :heart: